### PR TITLE
feat(deps): upgraded github.com/alexfalkowski/go-service/v2 to v2.331.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/alexfalkowski/go-client-template
 
 go 1.26.0
 
-require github.com/alexfalkowski/go-service/v2 v2.330.0
+require github.com/alexfalkowski/go-service/v2 v2.331.0
 
 require (
 	aidanwoods.dev/go-paseto v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1 h1:+JkXLHME8vLJafGhOH4ao
 github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1/go.mod h1:nuudZmJhzWtx2212z+pkuy7B6nkBqa+xwNXZHL1j8cg=
 github.com/alexfalkowski/go-health/v2 v2.18.0 h1:iSqrgmWdt/qaUNr/LsOvesehWFksAvHaM4Sy+O6RtTA=
 github.com/alexfalkowski/go-health/v2 v2.18.0/go.mod h1:9KSzMMK4aLqFoML8IfFoCEOxGsg5o2QY3GgI0E1FCLU=
-github.com/alexfalkowski/go-service/v2 v2.330.0 h1:jM87x8al3dQtAhn1iIEnGj6lYXt9FDvESbleaUSWTII=
-github.com/alexfalkowski/go-service/v2 v2.330.0/go.mod h1:Ps5P6MObFs3jO9CwpuJVGSCVLXiY9BliP/tjiM1Ilwg=
+github.com/alexfalkowski/go-service/v2 v2.331.0 h1:1BxbS85stWZbuvyT0UU0IoDMjIKnizerC4ATMQRTXi4=
+github.com/alexfalkowski/go-service/v2 v2.331.0/go.mod h1:Ps5P6MObFs3jO9CwpuJVGSCVLXiY9BliP/tjiM1Ilwg=
 github.com/alexfalkowski/go-sync v1.19.3 h1:sEmPvRa08IjuQ44YpglQDhXpbex1YPQCwRkKqarejQc=
 github.com/alexfalkowski/go-sync v1.19.3/go.mod h1:J2yBCIWJ1YAWqAJ94Bt2xroR2rOWlSyRBGqqNJDmLBw=
 github.com/arl/statsviz v0.8.0 h1:O6GjjVxEDxcByAucOSl29HaGYLXsuwA3ujJw8H9E7/U=


### PR DESCRIPTION
https://github.com/alexfalkowski/go-service/releases/tag/v2.331.0
