### PR TITLE
feat(deps): upgraded github.com/alexfalkowski/go-service/v2 to v2.352.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/alexfalkowski/go-client-template
 
 go 1.26.0
 
-require github.com/alexfalkowski/go-service/v2 v2.351.0
+require github.com/alexfalkowski/go-service/v2 v2.352.0
 
 require (
 	aidanwoods.dev/go-paseto v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1 h1:+JkXLHME8vLJafGhOH4ao
 github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1/go.mod h1:nuudZmJhzWtx2212z+pkuy7B6nkBqa+xwNXZHL1j8cg=
 github.com/alexfalkowski/go-health/v2 v2.19.1 h1:LS58hHOq3CbMFMf0DNp09t2AzDW0/H4TZ9KoXXxTQgo=
 github.com/alexfalkowski/go-health/v2 v2.19.1/go.mod h1:ypy+lqZpEh2HPNLqaDAv6wJBbxuouOZoPkkrtrMNXrA=
-github.com/alexfalkowski/go-service/v2 v2.351.0 h1:R1MGghZO+MDkqWIOsICLA9tzx94ZU90pBy3BFvwdj34=
-github.com/alexfalkowski/go-service/v2 v2.351.0/go.mod h1:JWavyYKktE4NJgI7APCsHctzsAU4+mCXMsOXeOrmDkA=
+github.com/alexfalkowski/go-service/v2 v2.352.0 h1:b/Al0tITKFao5EfmKcGFIkt2pcVwhVKR57rRRsyfQx0=
+github.com/alexfalkowski/go-service/v2 v2.352.0/go.mod h1:JWavyYKktE4NJgI7APCsHctzsAU4+mCXMsOXeOrmDkA=
 github.com/alexfalkowski/go-sync v1.21.0 h1:Aydt3mB0FwmaRPjDsO4ZHJIa0HdueTwRt0i4NQtNvsA=
 github.com/alexfalkowski/go-sync v1.21.0/go.mod h1:J2yBCIWJ1YAWqAJ94Bt2xroR2rOWlSyRBGqqNJDmLBw=
 github.com/arl/statsviz v0.8.0 h1:O6GjjVxEDxcByAucOSl29HaGYLXsuwA3ujJw8H9E7/U=

--- a/test/Gemfile.lock
+++ b/test/Gemfile.lock
@@ -76,7 +76,7 @@ GEM
     mustermann (3.1.1)
     netrc (0.11.0)
     nio4r (2.7.5)
-    nonnative (2.13.1)
+    nonnative (2.15.0)
       concurrent-ruby (>= 1, < 2)
       config (>= 5, < 6)
       cucumber (>= 7, < 12)


### PR DESCRIPTION
https://github.com/alexfalkowski/go-service/releases/tag/v2.352.0
