### PR TITLE
feat(deps): upgraded github.com/alexfalkowski/go-service/v2 to v2.358.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/alexfalkowski/go-client-template
 
 go 1.26.0
 
-require github.com/alexfalkowski/go-service/v2 v2.357.0
+require github.com/alexfalkowski/go-service/v2 v2.358.0
 
 require (
 	aidanwoods.dev/go-paseto v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1 h1:+JkXLHME8vLJafGhOH4ao
 github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1/go.mod h1:nuudZmJhzWtx2212z+pkuy7B6nkBqa+xwNXZHL1j8cg=
 github.com/alexfalkowski/go-health/v2 v2.19.2 h1:wsqGEevu5mF0+/3QNABgB7R2gpGk4j9fwuMtbzIVzuo=
 github.com/alexfalkowski/go-health/v2 v2.19.2/go.mod h1:ypy+lqZpEh2HPNLqaDAv6wJBbxuouOZoPkkrtrMNXrA=
-github.com/alexfalkowski/go-service/v2 v2.357.0 h1:ykp5h0vUAXrvkPGnXn/LVq8msJikq76e9+XUHeElhtM=
-github.com/alexfalkowski/go-service/v2 v2.357.0/go.mod h1:KXyYn+ZmNfRjMaZg7s31pg/7rfcbPgq6loH55JPa/+g=
+github.com/alexfalkowski/go-service/v2 v2.358.0 h1:h7X2xRvj4hxUna6tyshYMz587ioJ1UKxdI1rpGfUM/4=
+github.com/alexfalkowski/go-service/v2 v2.358.0/go.mod h1:KXyYn+ZmNfRjMaZg7s31pg/7rfcbPgq6loH55JPa/+g=
 github.com/alexfalkowski/go-sync v1.21.0 h1:Aydt3mB0FwmaRPjDsO4ZHJIa0HdueTwRt0i4NQtNvsA=
 github.com/alexfalkowski/go-sync v1.21.0/go.mod h1:J2yBCIWJ1YAWqAJ94Bt2xroR2rOWlSyRBGqqNJDmLBw=
 github.com/arl/statsviz v0.8.0 h1:O6GjjVxEDxcByAucOSl29HaGYLXsuwA3ujJw8H9E7/U=


### PR DESCRIPTION
https://github.com/alexfalkowski/go-service/releases/tag/v2.358.0
