### PR TITLE
feat(deps): upgraded github.com/alexfalkowski/go-service/v2 to v2.398.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/alexfalkowski/go-client-template
 
 go 1.26.0
 
-require github.com/alexfalkowski/go-service/v2 v2.397.0
+require github.com/alexfalkowski/go-service/v2 v2.398.0
 
 require (
 	aidanwoods.dev/go-paseto v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1 h1:+JkXLHME8vLJafGhOH4ao
 github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1/go.mod h1:nuudZmJhzWtx2212z+pkuy7B6nkBqa+xwNXZHL1j8cg=
 github.com/alexfalkowski/go-health/v2 v2.21.0 h1:eS1+ixrIvn5C0tl7Q41yICNI5NR+dZ2xGbrQ1lOd59k=
 github.com/alexfalkowski/go-health/v2 v2.21.0/go.mod h1:ypy+lqZpEh2HPNLqaDAv6wJBbxuouOZoPkkrtrMNXrA=
-github.com/alexfalkowski/go-service/v2 v2.397.0 h1:nDzoaStqyuYwr9k4+Awg6nROsI30kLXvWl8zMO00cAs=
-github.com/alexfalkowski/go-service/v2 v2.397.0/go.mod h1:aZQ9ZlKIyozDDvt/GYeVrb1MBm1skphSsfr+je1B4Nk=
+github.com/alexfalkowski/go-service/v2 v2.398.0 h1:ROLErzByHEhAZaz0QOLV6Idx9B4zvrvAMMNL8Iej09c=
+github.com/alexfalkowski/go-service/v2 v2.398.0/go.mod h1:aZQ9ZlKIyozDDvt/GYeVrb1MBm1skphSsfr+je1B4Nk=
 github.com/alexfalkowski/go-sync v1.21.0 h1:Aydt3mB0FwmaRPjDsO4ZHJIa0HdueTwRt0i4NQtNvsA=
 github.com/alexfalkowski/go-sync v1.21.0/go.mod h1:J2yBCIWJ1YAWqAJ94Bt2xroR2rOWlSyRBGqqNJDmLBw=
 github.com/arl/statsviz v0.8.0 h1:O6GjjVxEDxcByAucOSl29HaGYLXsuwA3ujJw8H9E7/U=


### PR DESCRIPTION
https://github.com/alexfalkowski/go-service/releases/tag/v2.398.0
