### PR TITLE
docs(agents): show help for test make default

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -1,1 +1,2 @@
+include ../bin/build/make/help.mak
 include ../bin/build/make/ruby.mak


### PR DESCRIPTION
Include the shared help target before the test Ruby make fragment.
