### PR TITLE
feat(deps): upgraded github.com/alexfalkowski/go-service/v2 to v2.634.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/alexfalkowski/go-client-template
 
 go 1.26.0
 
-require github.com/alexfalkowski/go-service/v2 v2.632.0
+require github.com/alexfalkowski/go-service/v2 v2.634.0
 
 require (
 	aidanwoods.dev/go-paseto v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1 h1:+JkXLHME8vLJafGhOH4ao
 github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1/go.mod h1:nuudZmJhzWtx2212z+pkuy7B6nkBqa+xwNXZHL1j8cg=
 github.com/alexfalkowski/go-health/v2 v2.33.0 h1:25fFPDnuIhZjLP1FYvzTayOMpwyjppzaxBXj/TPmkM4=
 github.com/alexfalkowski/go-health/v2 v2.33.0/go.mod h1:H11y8kNp0Ks3ayUNwjPOAV4314lGeH8MuwolYV+6l0M=
-github.com/alexfalkowski/go-service/v2 v2.632.0 h1:71oSbBnr6agd/VRo76Bz71hA8n9UysQT4Djcy1uC9C8=
-github.com/alexfalkowski/go-service/v2 v2.632.0/go.mod h1:NMuzgFLt0LR1fP4uOrOtwF7CQktXE5Yxx+4DfU6xGUY=
+github.com/alexfalkowski/go-service/v2 v2.634.0 h1:q1oGmbok1J+KS2zOZXYrRg94UauaKQs7Cr7QcMsK4W4=
+github.com/alexfalkowski/go-service/v2 v2.634.0/go.mod h1:NMuzgFLt0LR1fP4uOrOtwF7CQktXE5Yxx+4DfU6xGUY=
 github.com/alexfalkowski/go-sync v1.27.0 h1:Mnk9mhspHt/NzMwFvTyikAla1QF3GDufzuA1v8zvdcY=
 github.com/alexfalkowski/go-sync v1.27.0/go.mod h1:2vmRtpHHSoGPIiXJ7j3lm0GK2SI32XbYvvrjrZ+eo/k=
 github.com/arl/statsviz v0.8.0 h1:O6GjjVxEDxcByAucOSl29HaGYLXsuwA3ujJw8H9E7/U=

--- a/test/Gemfile.lock
+++ b/test/Gemfile.lock
@@ -70,7 +70,7 @@ GEM
     http-cookie (1.1.6)
       domain_name (~> 0.5)
     json (2.20.0)
-    language_server-protocol (3.17.0.5)
+    language_server-protocol (3.17.0.6)
     lint_roller (1.1.0)
     logger (1.7.0)
     memoist3 (1.0.0)


### PR DESCRIPTION
https://github.com/alexfalkowski/go-service/releases/tag/v2.634.0
