### PR TITLE
feat(deps): upgraded github.com/alexfalkowski/go-service/v2 to v2.636.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/alexfalkowski/go-client-template
 
 go 1.26.0
 
-require github.com/alexfalkowski/go-service/v2 v2.635.0
+require github.com/alexfalkowski/go-service/v2 v2.636.0
 
 require (
 	aidanwoods.dev/go-paseto v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1 h1:+JkXLHME8vLJafGhOH4ao
 github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1/go.mod h1:nuudZmJhzWtx2212z+pkuy7B6nkBqa+xwNXZHL1j8cg=
 github.com/alexfalkowski/go-health/v2 v2.33.0 h1:25fFPDnuIhZjLP1FYvzTayOMpwyjppzaxBXj/TPmkM4=
 github.com/alexfalkowski/go-health/v2 v2.33.0/go.mod h1:H11y8kNp0Ks3ayUNwjPOAV4314lGeH8MuwolYV+6l0M=
-github.com/alexfalkowski/go-service/v2 v2.635.0 h1:muA0IgEd3jSWgbZvTAdVJiSW3k50EaozfkJY5htwLBE=
-github.com/alexfalkowski/go-service/v2 v2.635.0/go.mod h1:X8aeA3w+M9k1ZYGGaLHuwB78zgYrBlA42BUE6bES7+w=
+github.com/alexfalkowski/go-service/v2 v2.636.0 h1:k6eJ8Ko03d1+3qTASnPNeYTMbkbqsc0aCoBSb4C8hnE=
+github.com/alexfalkowski/go-service/v2 v2.636.0/go.mod h1:X8aeA3w+M9k1ZYGGaLHuwB78zgYrBlA42BUE6bES7+w=
 github.com/alexfalkowski/go-sync v1.27.0 h1:Mnk9mhspHt/NzMwFvTyikAla1QF3GDufzuA1v8zvdcY=
 github.com/alexfalkowski/go-sync v1.27.0/go.mod h1:2vmRtpHHSoGPIiXJ7j3lm0GK2SI32XbYvvrjrZ+eo/k=
 github.com/arl/statsviz v0.8.0 h1:O6GjjVxEDxcByAucOSl29HaGYLXsuwA3ujJw8H9E7/U=


### PR DESCRIPTION
https://github.com/alexfalkowski/go-service/releases/tag/v2.636.0
